### PR TITLE
refactor: collapse not-found handling into one seam

### DIFF
--- a/app/api/decks.py
+++ b/app/api/decks.py
@@ -1,9 +1,7 @@
 import typing
 
 import fastapi
-from advanced_alchemy.exceptions import NotFoundError
 from modern_di_fastapi import FromDI
-from starlette import status
 
 from app import models, schemas
 from app.repositories import CardsRepository, DecksRepository
@@ -26,9 +24,6 @@ async def get_deck(
     decks_repository: DecksRepository = FromDI(DecksRepository),
 ) -> schemas.Deck:
     instance = await decks_repository.fetch_with_cards(deck_id)
-    if not instance:
-        raise fastapi.HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deck is not found")
-
     return typing.cast("schemas.Deck", instance)
 
 
@@ -38,11 +33,7 @@ async def update_deck(
     data: schemas.DeckCreate,
     decks_repository: DecksRepository = FromDI(DecksRepository),
 ) -> schemas.Deck:
-    try:
-        instance = await decks_repository.update(data=data.model_dump(), item_id=deck_id)
-    except NotFoundError:
-        raise fastapi.HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deck is not found") from None
-
+    instance = await decks_repository.update(data=data.model_dump(), item_id=deck_id)
     return typing.cast("schemas.Deck", instance)
 
 
@@ -69,9 +60,7 @@ async def get_card(
     card_id: int,
     cards_repository: CardsRepository = FromDI(CardsRepository),
 ) -> schemas.Card:
-    instance = await cards_repository.get_one_or_none(models.Card.id == card_id)
-    if not instance:
-        raise fastapi.HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Card is not found")
+    instance = await cards_repository.get_one(models.Card.id == card_id)
     return typing.cast("schemas.Card", instance)
 
 

--- a/app/application.py
+++ b/app/application.py
@@ -3,7 +3,7 @@ import typing
 
 import modern_di
 import modern_di_fastapi
-from advanced_alchemy.exceptions import DuplicateKeyError
+from advanced_alchemy.exceptions import DuplicateKeyError, NotFoundError
 from lite_bootstrap import FastAPIBootstrapper
 from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -37,5 +37,9 @@ def build_app() -> fastapi.FastAPI:
     app.add_exception_handler(
         DuplicateKeyError,
         exceptions.duplicate_key_error_handler,  # ty: ignore[invalid-argument-type]
+    )
+    app.add_exception_handler(
+        NotFoundError,
+        exceptions.not_found_error_handler,  # ty: ignore[invalid-argument-type]
     )
     return app

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -5,7 +5,7 @@ from starlette import status
 
 
 if TYPE_CHECKING:
-    from advanced_alchemy.exceptions import DuplicateKeyError
+    from advanced_alchemy.exceptions import DuplicateKeyError, NotFoundError
     from starlette.requests import Request
 
 
@@ -13,4 +13,11 @@ async def duplicate_key_error_handler(_: Request, exc: DuplicateKeyError) -> JSO
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content={"detail": exc.detail},
+    )
+
+
+async def not_found_error_handler(_: Request, __: NotFoundError) -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_404_NOT_FOUND,
+        content={"detail": "Not found"},
     )

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -17,8 +17,8 @@ class DecksRepository(SQLAlchemyAsyncRepositoryService[models.Deck]):
 
     repository_type = BaseRepository
 
-    async def fetch_with_cards(self, deck_id: int) -> models.Deck | None:
-        return await self.get_one_or_none(
+    async def fetch_with_cards(self, deck_id: int) -> models.Deck:
+        return await self.get_one(
             models.Deck.id == deck_id,
             load=[orm.selectinload(models.Deck.cards)],
         )


### PR DESCRIPTION
## What

Three handlers each re-derived the not-found → 404 policy, via **two different mechanisms**:

- `get_deck` / `get_card`: `get_one_or_none(...)` then `if not instance: raise HTTPException(404, ...)`
- `update_deck`: `try: ... except NotFoundError: raise HTTPException(404, ...)`

This consolidates that policy into **one seam**: a single `NotFoundError → 404` handler registered in `build_app`, mirroring the existing `DuplicateKeyError` handler.

Ports modern-python/litestar-sqlalchemy-template#27 to this template, adapted to FastAPI idioms (`JSONResponse` handler, `add_exception_handler`, `typing.cast` responses preserved).

## Changes

- `app/exceptions.py` — new `not_found_error_handler` returning `404 {"detail": "Not found"}`.
- `app/application.py` — register `NotFoundError: exceptions.not_found_error_handler`.
- `app/repositories.py` — `fetch_with_cards` tightens to `-> models.Deck`, using `get_one` (raises on miss) instead of `get_one_or_none`.
- `app/api/decks.py` — `get_deck` / `update_deck` / `get_card` drop all 404 code; `get_card` uses `get_one`. Removed now-unused imports (`NotFoundError`, starlette `status`, `HTTPException` usage).

No handler mentions 404 any more — the not-found decision lives where the data access happens, mapped to a response in one place.

## Decisions

- Seam = advanced-alchemy `NotFoundError` (the signal the repository already emits; matches the `DuplicateKeyError` convention).
- Reads use the raising variant; the raise is pushed behind `fetch_with_cards`.
- 404 body is generic `{"detail": "Not found"}` — advanced-alchemy's `NotFoundError.detail` is empty and no test asserts the message (the existing 404 tests assert status code only).

## Verification

- `just test` → 19 passed, 100% coverage
- `ruff format --check` / `ruff check --no-fix` / `ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)