### PR TITLE
refactor: deepen ORM→HTTP serialization behind a Collection seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,5 +70,5 @@ Endpoints inject repositories with `FromDI(Repository)` from `modern_di_fastapi`
 
 - Type-ignore syntax is `# ty: ignore[error-code]` (this project uses `ty`, not mypy). See `app/application.py:39` for an example.
 - Ruff is configured with `select = ["ALL"]` and a curated ignore list in `pyproject.toml`. Don't sprinkle `# noqa`; prefer fixing or extending the project ignore list if a rule is genuinely wrong for the codebase.
-- Routes return `typing.cast("schemas.X", obj)` over ORM/dict objects rather than constructing Pydantic models — the schemas use `from_attributes=True`.
+- Routes convert ORM objects to schemas explicitly, never via `typing.cast`. Single objects: `schemas.X.model_validate(instance)`. Collections: `schemas.Xs.from_models(objects)` (the `Collection[T]` seam in `app/schemas.py`). Both rely on `from_attributes=True`.
 - Line length is 120.

--- a/app/api/decks.py
+++ b/app/api/decks.py
@@ -15,7 +15,7 @@ async def list_decks(
     decks_repository: DecksRepository = FromDI(DecksRepository),
 ) -> schemas.Decks:
     objects = await decks_repository.get_many()
-    return typing.cast("schemas.Decks", {"items": objects})
+    return schemas.Decks.from_models(objects)
 
 
 @ROUTER.get("/decks/{deck_id}/")
@@ -24,7 +24,7 @@ async def get_deck(
     decks_repository: DecksRepository = FromDI(DecksRepository),
 ) -> schemas.Deck:
     instance = await decks_repository.fetch_with_cards(deck_id)
-    return typing.cast("schemas.Deck", instance)
+    return schemas.Deck.model_validate(instance)
 
 
 @ROUTER.put("/decks/{deck_id}/")
@@ -34,7 +34,7 @@ async def update_deck(
     decks_repository: DecksRepository = FromDI(DecksRepository),
 ) -> schemas.Deck:
     instance = await decks_repository.update(data=data.model_dump(), item_id=deck_id)
-    return typing.cast("schemas.Deck", instance)
+    return schemas.Deck.model_validate(instance)
 
 
 @ROUTER.post("/decks/")
@@ -43,7 +43,7 @@ async def create_deck(
     decks_repository: DecksRepository = FromDI(DecksRepository),
 ) -> schemas.Deck:
     instance = await decks_repository.create(data.model_dump())
-    return typing.cast("schemas.Deck", instance)
+    return schemas.Deck.model_validate(instance)
 
 
 @ROUTER.get("/decks/{deck_id}/cards/")
@@ -52,7 +52,7 @@ async def list_cards(
     cards_repository: CardsRepository = FromDI(CardsRepository),
 ) -> schemas.Cards:
     objects = await cards_repository.list_for_deck(deck_id)
-    return typing.cast("schemas.Cards", {"items": objects})
+    return schemas.Cards.from_models(objects)
 
 
 @ROUTER.get("/cards/{card_id}/")
@@ -61,7 +61,7 @@ async def get_card(
     cards_repository: CardsRepository = FromDI(CardsRepository),
 ) -> schemas.Card:
     instance = await cards_repository.get_one(models.Card.id == card_id)
-    return typing.cast("schemas.Card", instance)
+    return schemas.Card.model_validate(instance)
 
 
 @ROUTER.post("/decks/{deck_id}/cards/")
@@ -71,7 +71,7 @@ async def create_cards(
     cards_repository: CardsRepository = FromDI(CardsRepository),
 ) -> schemas.Cards:
     objects = await cards_repository.add_cards(deck_id, data)
-    return typing.cast("schemas.Cards", {"items": objects})
+    return schemas.Cards.from_models(objects)
 
 
 @ROUTER.put("/decks/{deck_id}/cards/")
@@ -81,4 +81,4 @@ async def update_cards(
     cards_repository: CardsRepository = FromDI(CardsRepository),
 ) -> schemas.Cards:
     objects = await cards_repository.upsert_cards(deck_id, data)
-    return typing.cast("schemas.Cards", {"items": objects})
+    return schemas.Cards.from_models(objects)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,9 +1,23 @@
+from typing import TYPE_CHECKING, Self
+
 import pydantic
 from pydantic import BaseModel, PositiveInt
 
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
 class Base(BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
+
+
+class Collection[T: Base](Base):
+    items: list[T]
+
+    @classmethod
+    def from_models(cls, objects: Iterable[object]) -> Self:
+        return cls.model_validate({"items": list(objects)})
 
 
 class CardBase(Base):
@@ -21,8 +35,8 @@ class Card(CardBase):
     deck_id: PositiveInt | None = None
 
 
-class Cards(Base):
-    items: list[Card]
+class Cards(Collection[Card]):
+    pass
 
 
 class DeckBase(Base):
@@ -39,5 +53,5 @@ class Deck(DeckBase):
     cards: list[Card] | None
 
 
-class Decks(Base):
-    items: list[Deck]
+class Decks(Collection[Deck]):
+    pass


### PR DESCRIPTION
## Problem

The persistence→HTTP serialization seam was shallow and leaked. Every list handler assembled its response envelope from raw ORM rows and lied to the type checker:

```python
return typing.cast("schemas.Decks", {"items": objects})
```

A `dict` of ORM objects is not a `schemas.Decks` — the `cast` just silenced `ty`. The envelope shape (`items`) was duplicated at every call site, and the real ORM→Pydantic conversion happened invisibly inside FastAPI's `response_model` re-validation. Single-object handlers had the same leak in miniature (`typing.cast("schemas.Deck", instance)`).

## Change

Port of modern-python/litestar-sqlalchemy-template#29, adapted to this repo's idiom and extended to converge on the litestar template's end state: **no casts anywhere, every handler routed through its schema.**

Introduce a deep generic `Collection[T]` seam in `app/schemas.py`:

```python
class Collection[T: Base](Base):
    items: list[T]

    @classmethod
    def from_models(cls, objects: Iterable[object]) -> Self:
        return cls.model_validate({"items": list(objects)})

class Cards(Collection[Card]): pass
class Decks(Collection[Deck]): pass
```

The ORM→schema coercion now happens once, behind a small interface. `model_validate` (param typed `Any`) absorbs the coercion honestly, so the leaky casts disappear:

- **Collection handlers** → `schemas.Xs.from_models(objects)`
- **Single-object handlers** → `schemas.X.model_validate(instance)`

`Decks`/`Cards` stay as named subclasses, so OpenAPI schema names are unchanged.

`CLAUDE.md`'s convention is updated to mandate explicit ORM→schema conversion and forbid `typing.cast`.

## Adaptation notes

- The litestar PR removed four `# ty: ignore[invalid-argument-type]` suppressions on `schemas.Decks(items=...)` constructors. This repo had none — instead it used `typing.cast(..., {"items": objects})`, the local form of the same leak. `from_models` replaces those.
- Litestar already used `model_validate` on single-object handlers, so its PR left them untouched. This repo used casts there, so killing them is what makes this repo converge on the litestar template's shape.
- The `return_dto=PydanticDTO` cleanup from the litestar PR has no FastAPI equivalent.

## Contract & tests

- **Wire contract unchanged** — `{items: [...]}`, same field names, same schema names.
- `ruff format --check`, `ruff check`, `ty check` all clean.
- **19 passed, 100% coverage held.**