### PR TITLE
refactor: split the Deck response contract from its detail view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,5 @@ Endpoints inject repositories with `FromDI(Repository)` from `modern_di_fastapi`
 - Type-ignore syntax is `# ty: ignore[error-code]` (this project uses `ty`, not mypy). See `app/application.py:39` for an example.
 - Ruff is configured with `select = ["ALL"]` and a curated ignore list in `pyproject.toml`. Don't sprinkle `# noqa`; prefer fixing or extending the project ignore list if a rule is genuinely wrong for the codebase.
 - Routes convert ORM objects to schemas explicitly, never via `typing.cast`. Single objects: `schemas.X.model_validate(instance)`. Collections: `schemas.Xs.from_models(objects)` (the `Collection[T]` seam in `app/schemas.py`). Both rely on `from_attributes=True`.
+- Deck responses are deliberately two-shaped: `list_decks`/`create_deck`/`update_deck` return the light `schemas.Deck` (no `cards`), while `get_deck` returns `schemas.DeckWithCards`. The split mirrors loading — lists/writes use `noload` (no cards query), detail uses `selectinload` via `fetch_with_cards` — so the type states exactly what each endpoint loads.
 - Line length is 120.

--- a/app/api/decks.py
+++ b/app/api/decks.py
@@ -22,9 +22,9 @@ async def list_decks(
 async def get_deck(
     deck_id: int,
     decks_repository: DecksRepository = FromDI(DecksRepository),
-) -> schemas.Deck:
+) -> schemas.DeckWithCards:
     instance = await decks_repository.fetch_with_cards(deck_id)
-    return schemas.Deck.model_validate(instance)
+    return schemas.DeckWithCards.model_validate(instance)
 
 
 @ROUTER.put("/decks/{deck_id}/")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -49,8 +49,15 @@ class DeckCreate(DeckBase):
 
 
 class Deck(DeckBase):
+    """Light deck view for lists and writes; cards are not loaded."""
+
     id: PositiveInt
-    cards: list[Card] | None
+
+
+class DeckWithCards(Deck):
+    """Deck detail view; cards are eager-loaded (selectinload) and always present."""
+
+    cards: list[Card]
 
 
 class Decks(Collection[Deck]):


### PR DESCRIPTION
## Problem

One `Deck` schema served two endpoints with different card-loading strategies, leaking the difference into the type:

```python
class Deck(DeckBase):
    id: PositiveInt
    cards: list[Card] | None
```

- `get_deck` → `fetch_with_cards` (`selectinload`) → cards populated.
- `list_decks` / `create_deck` / `update_deck` → relationship is `lazy="noload"`, so `.cards` returns `[]` **without loading**.

So `list_decks` reported `cards: []` for *every* deck even when the deck has cards — the list contract was lying. The `| None` was also dead: `noload` yields `[]`, never `None`.

## Change

Split the one schema into two:

```python
class Deck(DeckBase):
    """Light deck view for lists and writes; cards are not loaded."""
    id: PositiveInt

class DeckWithCards(Deck):
    """Deck detail view; cards are eager-loaded (selectinload) and always present."""
    cards: list[Card]
```

- `get_deck` → `DeckWithCards` (cards always present, non-optional)
- `list_decks` → `Decks` (`Collection[Deck]`), `create_deck` / `update_deck` → `Deck`

Each endpoint's return type now states exactly what it loads. The dead `| None` is gone. The two-shape convention is documented in **CLAUDE.md** (Conventions) and in docstrings on the schemas.

## Contract change ⚠️

Intentional: the `cards` key **disappears** from `list` / `create` / `update` responses (they never loaded cards anyway). `get_deck` is unchanged. Any client reading `cards` off a list response is affected.

## Tests

`test_get_one_deck` locks `DeckWithCards` (asserts `cards`); list/create/update tests never asserted `cards`, so they stay green. **19 passed, 100% coverage.** `ruff format --check`, `ruff check --no-fix`, `ty check` all pass.

Ports modern-python/litestar-sqlalchemy-template#30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)