### PR TITLE
test: lock in instance-attribute reads in api_bootstrapper_config

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,10 @@
+from app.settings import Settings
+
+
+def test_api_bootstrapper_config_reads_instance_not_global() -> None:
+    custom = Settings(service_name="custom-service", service_version="9.9.9")
+
+    config = custom.api_bootstrapper_config
+
+    assert config.service_name == "custom-service"
+    assert config.service_version == "9.9.9"


### PR DESCRIPTION
## Context

Ports the regression test from [litestar-sqlalchemy-template#32](https://github.com/modern-python/litestar-sqlalchemy-template/pull/32).

That PR fixed a bug where `Settings.api_bootstrapper_config` built its config from the module-global `settings` singleton instead of `self`, so any non-singleton `Settings` instance (or access during the singleton's own construction) silently produced the singleton's values.

## State in this repo

The production code here **already** reads `self.*` — the bug is absent. What was missing was a test guarding against it being reintroduced. This PR adds only that test.

## Test

`tests/test_settings.py` constructs `Settings(service_name="custom-service", service_version="9.9.9")` and asserts `api_bootstrapper_config` reflects the instance rather than the global. Passes GREEN against the current (correct) code; would fail if the `self.*` reads ever regressed to `settings.*`.

`ruff format --check`, `ruff check --no-fix`, and `ty check` all pass on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)