### PR TITLE
test: lock that the deck list omits cards

### DIFF
--- a/tests/test_decks.py
+++ b/tests/test_decks.py
@@ -35,6 +35,16 @@ async def test_get_decks(client: AsyncClient) -> None:
         assert v == getattr(deck, k)
 
 
+async def test_list_decks_omits_cards(client: AsyncClient) -> None:
+    deck = await factories.DeckModelFactory.create_async()
+    await factories.CardModelFactory.create_async(deck_id=deck.id)
+
+    response = await client.get("/api/decks/")
+    assert response.status_code == status.HTTP_200_OK
+    item = response.json()["items"][0]
+    assert "cards" not in item
+
+
 async def test_get_one_deck(client: AsyncClient) -> None:
     deck = await factories.DeckModelFactory.create_async()
     card = await factories.CardModelFactory.create_async(deck_id=deck.id)


### PR DESCRIPTION
## Context

Ports the regression test from [litestar-sqlalchemy-template#33](https://github.com/modern-python/litestar-sqlalchemy-template/pull/33), adapted to this repo's `from fastapi import status` convention.

## Why

The Deck response contract is deliberately two-shaped (per CLAUDE.md): light `schemas.Deck` for `list_decks`/`create_deck`/`update_deck` (no `cards`), and `schemas.DeckWithCards` for `get_deck`. No test asserted that `cards` is *absent* from list responses, so that half of the contract wasn't pinned — existing tests would pass even if `cards` leaked back into the light schema.

## What

`test_list_decks_omits_cards` creates a deck **with** a card, then asserts the list item has no `cards` key. It would catch a regression that re-added `cards` to the light contract. `test_get_one_deck` already locks the other half (detail includes cards).

Full suite: 21 passed, 100% coverage. Lint + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)