### PR TITLE
test: lock CORS preflight allows write methods

### DIFF
--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+async def test_cors_preflight_allows_write_methods(client: AsyncClient) -> None:
+    response = await client.options(
+        "/api/decks/",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    allow_methods = response.headers.get("access-control-allow-methods", "")
+    assert "POST" in allow_methods
+    assert "PUT" in allow_methods


### PR DESCRIPTION
## Context

Ports the regression test from [modern-python/litestar-sqlalchemy-template#34](https://github.com/modern-python/litestar-sqlalchemy-template/pull/34).

That PR fixed a CORS bug where the defaults were `[""]` (neither allow-all `["*"]` nor empty `[]`). In **this** template the `settings.py` defaults already ship correct:

```python
cors_allowed_methods: list[str] = ["*"]
cors_allowed_headers: list[str] = ["*"]
```

…but there was no test guarding the preflight contract, so a future regression to `[""]` would slip through silently.

## Change

Add `tests/test_cors.py`: a preflight `OPTIONS /api/decks/` from the shipped dev origin (`http://localhost:5173`) with `Access-Control-Request-Method: POST`, asserting `POST`/`PUT` appear in `Access-Control-Allow-Methods`. Exercises the real settings → lite-bootstrap → Starlette `CORSMiddleware` wiring through the existing `client` fixture. No DB needed (preflight is handled in middleware before routing).

## Verification

- **GREEN** with the current `["*"]` defaults.
- **RED** if methods regress to `[""]`: Starlette returns preflight `400 Bad Request`, `POST` absent — confirming the test is a genuine guard.
- `ruff format --check`, `ruff check --no-fix`, `ty check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)