### PR TITLE
Align pyproject description with the GitHub description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "fastapi-sqlalchemy-template"
 version = "0"
-description = "Async template on FastAPI and SQLAlchemy 2"
+description = "Dockerized FastAPI + SQLAlchemy 2 + PostgreSQL app template with DI"
 readme = "readme.md"
 requires-python = ">=3.14"
 authors = [


### PR DESCRIPTION
Part of an org-wide metadata-consistency sweep. The three metadata surfaces (GitHub description, pyproject `description`, profile blurb) now carry one canonical one-liner; the GitHub wording is canonical for this template. One-line change to `pyproject.toml`.